### PR TITLE
feat: add duplicate check on test names

### DIFF
--- a/src/expectation.sml
+++ b/src/expectation.sml
@@ -35,9 +35,8 @@ struct
           | Invalid invalid =>
               case invalid of
                 EmptyList => (description ^ ": " ^ "list cannot be empty.")
-              | DuplicatedName => (description ^ ": " ^ "duplicated name.")
+              | DuplicatedName => description
               | BadDescription => (description ^ ": " ^ "bad description.")
         end
-
   val pass = Pass
 end

--- a/src/internal.sml
+++ b/src/internal.sml
@@ -1,5 +1,7 @@
 structure Internal =
 struct
+  datatype ('a, 'e) Result = OK of 'a | ERROR of 'e
+
   structure List =
   struct
     open List
@@ -40,21 +42,29 @@ struct
 
   fun duplicatedNames tests =
     let
-      fun buildname test =
+      fun names test =
         case test of
           Labeled (description, _) => [description]
-        | Batch subtests => List.concatMap buildname subtests
+        | Batch subtests => List.concatMap names subtests
         | UnitTest _ => []
-        | Skipped subTest => buildname subTest
-        | Focused subTest => buildname subTest
+        | Skipped subTest => names subTest
+        | Focused subTest => names subTest
 
-      fun duplicates [] = []
-        | duplicates (x :: xs) =
-            if (List.exists (fn y => x = y) xs) then [x] else duplicates xs
+      (* we don't have a Set structure for now ;( *)
+      fun insertIfNotExists item l =
+        if List.exists (fn x => x = item) l then l else item :: l
 
-      val names = List.concatMap buildname tests
-      val duplicatedNames = duplicates names
+      fun accumDuplicates (newName, (dups, uniques)) =
+        if List.exists (fn unique => unique = newName) uniques then
+          (insertIfNotExists newName dups, uniques)
+        else
+          (dups, insertIfNotExists newName uniques)
+
+      val accumulatedDuplicates = List.concatMap names tests
+
+      val (accDups, accUniques) =
+        List.foldl accumDuplicates ([], []) accumulatedDuplicates
     in
-      if List.null duplicatedNames then NONE else SOME duplicatedNames
+      if List.null accDups then OK accUniques else ERROR accDups
     end
 end

--- a/tests/src/expectation.sml
+++ b/tests/src/expectation.sml
@@ -76,11 +76,10 @@ struct
 
                    , test "DuplicatedName" (fn _ =>
                        let
-                         val expected =
-                           "Expectation.DuplicatedName: duplicated name."
+                         val expected = "Expectation.DuplicatedName"
                          val expectation =
                            Expectation.fail
-                             { description = "Expectation.DuplicatedName"
+                             { description = expected
                              , reason =
                                  Expectation.Invalid Expectation.DuplicatedName
                              }

--- a/tests/src/main.sml
+++ b/tests/src/main.sml
@@ -2,8 +2,7 @@ structure Main =
 struct
   fun main (_: string, _: string list) =
     let open Test
-    in
-      run (concat [TestExpect.tests, TestRunner.tests, TestExpectation.tests])
+    in run (concat [TestExpect.tests, TestRunner.tests, TestExpectation.tests])
     end
 end
 

--- a/tests/src/runner.sml
+++ b/tests/src/runner.sml
@@ -7,7 +7,7 @@ struct
       open TestHelper
     in
       describe "Runner"
-        [ describe "fromtest"
+        [ describe "fromTest"
             [ test "focus inside a focus has no effect" (fn _ =>
                 let
                   val tests = describe "three tests"
@@ -19,7 +19,7 @@ struct
                         ])
                     ]
 
-                  val runners = fromtest tests
+                  val runners = fromTest tests
                   val expected = 2
                   val actual =
                     case runners of
@@ -40,7 +40,7 @@ struct
                         ])
                     ]
 
-                  val runners = fromtest tests
+                  val runners = fromTest tests
                   val expected = 1
                   val actual =
                     case runners of
@@ -61,7 +61,7 @@ struct
                         ])
                     ]
 
-                  val runners = fromtest tests
+                  val runners = fromTest tests
                   val expected = 1
                   val actual =
                     case runners of


### PR DESCRIPTION
This PR introduces a feature that would not allow the following cases:

```sml
describe "foo" 
  [ test "bar" (fn _ => Expect.pass)
  , test "bar" (fn _ => Expect.pass) ]
(*
=== FAIL: foo
    The `describe` 'foo' Contains multiple tests named 'bar'. Rename them to know which is which.
*)
```

```sml
describe "foo" 
  [ describe "bar" 
      [ test "bar" (fn _ => Expect.pass) ] ]
(*
=== FAIL: foo.bar
    The test 'bar' contains a child test of the same name 'bar'. Rename them to know which is which.
*)
```